### PR TITLE
Check for more open menus when using hotkeys

### DIFF
--- a/Source/Scripts/AIAgentPapyrusFunctions.psc
+++ b/Source/Scripts/AIAgentPapyrusFunctions.psc
@@ -361,8 +361,6 @@ Bool Function SafeProcess(bool allowMenuMode = false)
    && (!UI.IsMenuOpen("Crafting Menu")) \
    && (!UI.IsMenuOpen("MessageBoxMenu")) \
    && (!UI.IsMenuOpen("ContainerMenu")) \
-   && (!UI.IsMenuOpen("InventoryMenu")) \
-   && (!UI.IsMenuOpen("BarterMenu")) \
    && (!UI.IsTextInputEnabled()) \
    && (!UI.IsMenuOpen("LootMenu")) \
    && (!UI.IsMenuOpen("RaceSex Menu")) \
@@ -373,8 +371,6 @@ Bool Function SafeProcess(bool allowMenuMode = false)
       ;Crafting Menu to block when crafting menus are open - game is not paused so IsInMenuMode does not work
       ;MessageBoxMenu to block when message boxes are open - while they pause the game, they do not trigger IsInMenuMode
       ;ContainerMenu to block when containers are accessed - while they pause the game, they do not trigger IsInMenuMode
-      ;InventoryMenu to block when inventory is open - when used with Skyrim Souls
-      ;BarterMenu to block when buy items in shop - when used with Skyrim Souls
       ;IsTextInputEnabled to block when editable text fields are open
 	  ;LootMenu to block when looting - when used with Quick Loot
 	  ;RaceSex Menu to block during character creation - when used with RaceMenu

--- a/Source/Scripts/AIAgentPapyrusFunctions.psc
+++ b/Source/Scripts/AIAgentPapyrusFunctions.psc
@@ -356,7 +356,6 @@ endEvent
 
 Bool Function SafeProcess(bool allowMenuMode = false)
    If (allowMenuMode || !Utility.IsInMenuMode()) \
-   && (!UI.IsMenuOpen("Dialogue Menu")) \
    && (!UI.IsMenuOpen("Console")) \
    && (!UI.IsMenuOpen("Crafting Menu")) \
    && (!UI.IsMenuOpen("MessageBoxMenu")) \
@@ -366,7 +365,6 @@ Bool Function SafeProcess(bool allowMenuMode = false)
    && (!UI.IsMenuOpen("RaceSex Menu")) \
    && (!UI.IsMenuOpen("listmenu"))
       ;IsInMenuMode to block when game is paused with menus open
-      ;Dialogue Menu to block when dialog is open
       ;Console to block when console is open - console does not trigger IsInMenuMode and thus needs its own check
       ;Crafting Menu to block when crafting menus are open - game is not paused so IsInMenuMode does not work
       ;MessageBoxMenu to block when message boxes are open - while they pause the game, they do not trigger IsInMenuMode

--- a/Source/Scripts/AIAgentPapyrusFunctions.psc
+++ b/Source/Scripts/AIAgentPapyrusFunctions.psc
@@ -26,7 +26,7 @@ EndEvent
 
 Event OnKeyUp(int keyCode, float holdTime)
 	If(keyCode == _currentKeyVoice)
-		if (!UI.IsMenuOpen("Book Menu"))
+		if (!UI.IsMenuOpen("Book Menu") && SafeProcess())
 			AIAgentFunctions.stopRecording(_currentKeyVoice)
 			;WebSocketSTT.StopRecordVoice(_currentKeyVoice);
 			Debug.Notification("[CHIM] Recording end");
@@ -38,7 +38,7 @@ Event OnKeyDown(int keyCode)
    
   If(keyCode == _currentKey)
   
-	If Utility.IsInMenuMode()
+	If !SafeProcess()
       Return
     EndIf
 	
@@ -56,7 +56,7 @@ Event OnKeyDown(int keyCode)
 	if (UI.IsMenuOpen("Book Menu"))
 		;Debug.Notification("[CHIM] lazy reader...");
 		AIAgentFunctions.sendMessage("Please, summarize this book i've just found.","chatnf_book")
-	else
+	elseif SafeProcess()
         AIAgentFunctions.recordSoundEx(_currentKeyVoice)
 		;WebSocketSTT.StartRecordVoice(_currentKeyVoice);
 		Debug.Notification("[CHIM] recording....");
@@ -68,7 +68,7 @@ Event OnKeyDown(int keyCode)
 		;Debug.Notification("[CHIM] lazy reader...");
 		AIAgentFunctions.sendMessage("Please, summarize this book i've just found.","chatnf_book")
 	else
-		If Utility.IsInMenuMode()
+		If !SafeProcess()
 		  Return
 		EndIf
 
@@ -166,22 +166,22 @@ Event OnKeyDown(int keyCode)
 	endif
   EndIf
   If(keyCode == _currentDiaryKey)
-	If Utility.IsInMenuMode()
+	If !SafeProcess()
 		Return
 	EndIf
 	AIAgentFunctions.sendMessage("Please, update your diary","diary")
   EndIf
   If(keyCode == _currentCModelKey)
-	If Utility.IsInMenuMode()
+	If Utility.IsInMenuMode() && SafeProcess(true)
 		AIAgentFunctions.logMessage("Model change requested","togglemodel")
-		Return
+	ElseIf SafeProcess()
+		Actor target=AIAgentFunctions.getClosestAgent()
+		AIAgentFunctions.logMessageForActor("Model change requested","togglemodel",target.GetDisplayName())
 	EndIf
-	Actor target=AIAgentFunctions.getClosestAgent()
-	AIAgentFunctions.logMessageForActor("Model change requested","togglemodel",target.GetDisplayName())
   EndIf
   
   If(keyCode == _currentCSoulgaze)
-	If Utility.IsInMenuMode()
+	If !SafeProcess()
 		Return
 	EndIf
 	
@@ -190,7 +190,7 @@ Event OnKeyDown(int keyCode)
   EndIf
   
   If(keyCode == _currentCtl)
-	If Utility.IsInMenuMode()
+	If !SafeProcess()
 		Return
 	EndIf
 	
@@ -354,4 +354,33 @@ Event OnTrackedStatsEvent(string asStatFilter, int aiStatValue)
 	endif
 endEvent
 
-
+Bool Function SafeProcess(bool allowMenuMode = false)
+   If (allowMenuMode || !Utility.IsInMenuMode()) \
+   && (!UI.IsMenuOpen("Dialogue Menu")) \
+   && (!UI.IsMenuOpen("Console")) \
+   && (!UI.IsMenuOpen("Crafting Menu")) \
+   && (!UI.IsMenuOpen("MessageBoxMenu")) \
+   && (!UI.IsMenuOpen("ContainerMenu")) \
+   && (!UI.IsMenuOpen("InventoryMenu")) \
+   && (!UI.IsMenuOpen("BarterMenu")) \
+   && (!UI.IsTextInputEnabled()) \
+   && (!UI.IsMenuOpen("LootMenu")) \
+   && (!UI.IsMenuOpen("RaceSex Menu")) \
+   && (!UI.IsMenuOpen("listmenu"))
+      ;IsInMenuMode to block when game is paused with menus open
+      ;Dialogue Menu to block when dialog is open
+      ;Console to block when console is open - console does not trigger IsInMenuMode and thus needs its own check
+      ;Crafting Menu to block when crafting menus are open - game is not paused so IsInMenuMode does not work
+      ;MessageBoxMenu to block when message boxes are open - while they pause the game, they do not trigger IsInMenuMode
+      ;ContainerMenu to block when containers are accessed - while they pause the game, they do not trigger IsInMenuMode
+      ;InventoryMenu to block when inventory is open - when used with Skyrim Souls
+      ;BarterMenu to block when buy items in shop - when used with Skyrim Souls
+      ;IsTextInputEnabled to block when editable text fields are open
+	  ;LootMenu to block when looting - when used with Quick Loot
+	  ;RaceSex Menu to block during character creation - when used with RaceMenu
+	  ;listmenu to block during list selection - comes from UIExtensions
+      Return True
+   Else
+      Return False
+   EndIf
+EndFunction


### PR DESCRIPTION
Before using a hotkey (text input, voice chat, activate ai, etc), we use IsMenuMode() to check if a menu is open. But that function misses some menus where the hotkey should also be disabled, like the console and during text input.
This PR adds a SafeProcess function that checks for more menus.