### PR TITLE
feat: implement PrismaUI "HUD layout" settings (corner placements; edge gap)

### DIFF
--- a/PrismaUI/views/CHIM/aiview.css
+++ b/PrismaUI/views/CHIM/aiview.css
@@ -112,12 +112,19 @@ body {
     border-color: #ff6b6b;
 }
 
+/* Corner placement - driven by layout.js */
+/* left-panel: default top-left */
+.left-panel.chim-corner-top-left     { top: 20px !important;    left: 20px !important;  bottom: auto !important; right: auto !important; }
+.left-panel.chim-corner-top-right    { top: 20px !important;    right: 20px !important; bottom: auto !important; left: auto !important;  }
+.left-panel.chim-corner-bottom-left  { bottom: 20px !important; left: 20px !important;  top: auto !important;    right: auto !important; }
+.left-panel.chim-corner-bottom-right { bottom: 20px !important; right: 20px !important; top: auto !important;    left: auto !important;  }
+
 /* =========================
    LEFT PANEL - Identity & Profile
    ========================= */
 .left-panel {
     position: fixed;
-    top: 70px;
+    top: 20px;
     left: 20px;
     width: 340px;
     max-height: calc(100vh - 90px);
@@ -133,12 +140,18 @@ body {
     flex-direction: column;
 }
 
+/* right-panel: default top-right */
+.right-panel.chim-corner-top-left     { top: 20px !important;    left: 20px !important;  bottom: auto !important; right: auto !important; }
+.right-panel.chim-corner-top-right    { top: 20px !important;    right: 20px !important; bottom: auto !important; left: auto !important;  }
+.right-panel.chim-corner-bottom-left  { bottom: 20px !important; left: 20px !important;  top: auto !important;    right: auto !important; }
+.right-panel.chim-corner-bottom-right { bottom: 20px !important; right: 20px !important; top: auto !important;    left: auto !important;  }
+
 /* =========================
    RIGHT PANEL - Settings Only (Wider)
    ========================= */
 .right-panel {
     position: fixed;
-    top: 70px;
+    top: 20px;
     right: 20px;
     width: 320px;
     max-height: 400px;
@@ -153,6 +166,12 @@ body {
     display: flex;
     flex-direction: column;
 }
+
+/* bio-panel: default bottom-right */
+.bio-panel.chim-corner-top-left     { top: 20px !important;    left: 20px !important;  bottom: auto !important; right: auto !important; }
+.bio-panel.chim-corner-top-right    { top: 20px !important;    right: 20px !important; bottom: auto !important; left: auto !important;  }
+.bio-panel.chim-corner-bottom-left  { bottom: 20px !important; left: 20px !important;  top: auto !important;    right: auto !important; }
+.bio-panel.chim-corner-bottom-right { bottom: 20px !important; right: 20px !important; top: auto !important;    left: auto !important;  }
 
 /* =========================
    BIOGRAPHY PANEL - Bottom Right (2-column, WIDER with Relationships)

--- a/PrismaUI/views/CHIM/aiview.html
+++ b/PrismaUI/views/CHIM/aiview.html
@@ -211,6 +211,7 @@
             </div>
         </div>
     </div>
+    <script src="layout.js"></script>
     <script src="aiview.js"></script>
 </body>
 </html>

--- a/PrismaUI/views/CHIM/aiview.js
+++ b/PrismaUI/views/CHIM/aiview.js
@@ -374,6 +374,13 @@
         // Don't clear it, so user knows which NPC triggered the error
     };
 
+    // Apply corner placement via shared layout manager
+    if (window.chimLayout) {
+        window.chimLayout.apply(document.getElementById('left-panel'),  'aiview_identity');
+        window.chimLayout.apply(document.getElementById('right-panel'), 'aiview_settings');
+        window.chimLayout.apply(document.getElementById('bio-panel'),   'aiview_bio');
+    }
+
     // Initialize
     showLoading();
     console.log('CHIM AI View (Multi-Window HUD) initialized');

--- a/PrismaUI/views/CHIM/chatbox.css
+++ b/PrismaUI/views/CHIM/chatbox.css
@@ -39,6 +39,12 @@ body {
     display: none;
 }
 
+/* Corner placement - driven by layout.js */
+#chim-chatbox.chim-corner-bottom-left  { bottom: 20px !important; left: 20px !important;  top: auto !important;  right: auto !important; }
+#chim-chatbox.chim-corner-bottom-right { bottom: 20px !important; right: 20px !important; top: auto !important;  left: auto !important;  }
+#chim-chatbox.chim-corner-top-left     { top: 20px !important;    left: 20px !important;  bottom: auto !important; right: auto !important; }
+#chim-chatbox.chim-corner-top-right    { top: 20px !important;    right: 20px !important; bottom: auto !important; left: auto !important;  }
+
 @keyframes slideIn {
     from {
         opacity: 0;

--- a/PrismaUI/views/CHIM/chatbox.html
+++ b/PrismaUI/views/CHIM/chatbox.html
@@ -89,6 +89,7 @@
             </div>
         </div>
     </div>
+    <script src="layout.js"></script>
     <script src="chatbox.js"></script>
 </body>
 </html>

--- a/PrismaUI/views/CHIM/chatbox.js
+++ b/PrismaUI/views/CHIM/chatbox.js
@@ -360,5 +360,10 @@
         }
     });
 
+    // Apply corner placement via shared layout manager
+    if (window.chimLayout) {
+        window.chimLayout.apply(chatboxRoot, 'chatbox');
+    }
+
     console.log('[Chatbox] Initialized - display mode + focus modal input');
 })();

--- a/PrismaUI/views/CHIM/layout.js
+++ b/PrismaUI/views/CHIM/layout.js
@@ -1,0 +1,196 @@
+/**
+ * CHIM Layout Manager
+ * Shared module for corner-placement of all HUD/panel views.
+ */
+
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'chim_layout_corners';
+    var GAP_STORAGE_KEY = 'chim_layout_gap';
+    var DEFAULT_GAP = 20;
+
+    var VIEW_DEFAULTS = {
+        'chatbox':          'bottom-left',
+        'overlay':          'top-right',
+        'status_hud':       'top-right',
+        'aiview_identity':  'top-left',
+        'aiview_settings':  'top-right',
+        'aiview_bio':       'bottom-right'
+    };
+
+    var liveElements = {};
+
+    function loadAll() {
+        try {
+            var data = localStorage.getItem(STORAGE_KEY);
+            return data ? JSON.parse(data) : {};
+        } catch (e) {
+            console.warn('[chimLayout] localStorage read failed:', e);
+            return {};
+        }
+    }
+
+    function saveAll(map) {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+        } catch (e) {
+            console.warn('[chimLayout] localStorage write failed:', e);
+        }
+    }
+
+    var CORNER_CLASSES = [
+        'chim-corner-top-left',
+        'chim-corner-top-right',
+        'chim-corner-bottom-left',
+        'chim-corner-bottom-right'
+    ];
+
+    function applyCornerClass(el, corner, gap) {
+        for (var i = 0; i < CORNER_CLASSES.length; i++) {
+            el.classList.remove(CORNER_CLASSES[i]);
+        }
+        if (corner) {
+            el.classList.add('chim-corner-' + corner);
+        }
+        
+        // Apply gap dynamically
+        var gapPx = (gap !== undefined ? gap : DEFAULT_GAP) + 'px';
+        
+        // Reset all inline positioning first
+        el.style.removeProperty('top');
+        el.style.removeProperty('bottom');
+        el.style.removeProperty('left');
+        el.style.removeProperty('right');
+        
+        // Apply new positioning based on corner with !important to override CSS classes
+        if (corner === 'top-left') {
+            el.style.setProperty('top', gapPx, 'important');
+            el.style.setProperty('left', gapPx, 'important');
+            el.style.setProperty('bottom', 'auto', 'important');
+            el.style.setProperty('right', 'auto', 'important');
+        } else if (corner === 'top-right') {
+            el.style.setProperty('top', gapPx, 'important');
+            el.style.setProperty('right', gapPx, 'important');
+            el.style.setProperty('bottom', 'auto', 'important');
+            el.style.setProperty('left', 'auto', 'important');
+        } else if (corner === 'bottom-left') {
+            el.style.setProperty('bottom', gapPx, 'important');
+            el.style.setProperty('left', gapPx, 'important');
+            el.style.setProperty('top', 'auto', 'important');
+            el.style.setProperty('right', 'auto', 'important');
+        } else if (corner === 'bottom-right') {
+            el.style.setProperty('bottom', gapPx, 'important');
+            el.style.setProperty('right', gapPx, 'important');
+            el.style.setProperty('top', 'auto', 'important');
+            el.style.setProperty('left', 'auto', 'important');
+        }
+
+        // Force reflow to ensure WebKit applies the new positioning immediately
+        void el.offsetHeight;
+    }
+
+    var chimLayout = {
+        views: VIEW_DEFAULTS,
+
+        getCorner: function(viewId) {
+            var saved = loadAll();
+            return saved[viewId] || VIEW_DEFAULTS[viewId] || 'top-left';
+        },
+
+        getGap: function() {
+            try {
+                var gap = localStorage.getItem(GAP_STORAGE_KEY);
+                return gap !== null ? parseInt(gap, 10) : DEFAULT_GAP;
+            } catch (e) {
+                return DEFAULT_GAP;
+            }
+        },
+
+        setGap: function(gap) {
+            try {
+                localStorage.setItem(GAP_STORAGE_KEY, gap.toString());
+            } catch (e) {}
+            
+            var map = loadAll();
+            for (var viewId in liveElements) {
+                if (liveElements.hasOwnProperty(viewId)) {
+                    var corner = map[viewId] || VIEW_DEFAULTS[viewId] || 'top-left';
+                    applyCornerClass(liveElements[viewId], corner, gap);
+                }
+            }
+        },
+
+        setCorner: function(viewId, corner) {
+            var valid = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+            if (valid.indexOf(corner) === -1) return;
+
+            var map = loadAll();
+            map[viewId] = corner;
+            saveAll(map);
+
+            if (liveElements[viewId]) {
+                applyCornerClass(liveElements[viewId], corner, this.getGap());
+            }
+
+            console.log('[chimLayout] setCorner', viewId, '->', corner);
+        },
+
+        apply: function(el, viewId, defaultCorner) {
+            if (!el) return;
+            liveElements[viewId] = el;
+
+            if (defaultCorner && !(viewId in VIEW_DEFAULTS)) {
+                VIEW_DEFAULTS[viewId] = defaultCorner;
+            }
+
+            var corner = this.getCorner(viewId);
+            applyCornerClass(el, corner, this.getGap());
+            console.log('[chimLayout] apply', viewId, '->', corner);
+        }
+    };
+
+    // Listen for cross-view storage changes (if WebViews share localStorage)
+    window.addEventListener('storage', function(e) {
+        if (e.key === STORAGE_KEY || e.key === GAP_STORAGE_KEY) {
+            var map = loadAll();
+            var gap = chimLayout.getGap();
+            for (var viewId in liveElements) {
+                if (liveElements.hasOwnProperty(viewId)) {
+                    var corner = map[viewId] || VIEW_DEFAULTS[viewId] || 'top-left';
+                    applyCornerClass(liveElements[viewId], corner, gap);
+                }
+            }
+        }
+    });
+
+    // Fallback: Poll for changes (WebKit often doesn't fire 'storage' events for file:// URLs)
+    var lastSavedState = null;
+    var lastSavedGap = null;
+    try {
+        lastSavedState = localStorage.getItem(STORAGE_KEY);
+        lastSavedGap = localStorage.getItem(GAP_STORAGE_KEY);
+    } catch (e) {}
+
+    setInterval(function() {
+        try {
+            var currentState = localStorage.getItem(STORAGE_KEY);
+            var currentGap = localStorage.getItem(GAP_STORAGE_KEY);
+            if (currentState !== lastSavedState || currentGap !== lastSavedGap) {
+                lastSavedState = currentState;
+                lastSavedGap = currentGap;
+                var map = currentState ? JSON.parse(currentState) : {};
+                var gap = currentGap !== null ? parseInt(currentGap, 10) : DEFAULT_GAP;
+                for (var viewId in liveElements) {
+                    if (liveElements.hasOwnProperty(viewId)) {
+                        var corner = map[viewId] || VIEW_DEFAULTS[viewId] || 'top-left';
+                        applyCornerClass(liveElements[viewId], corner, gap);
+                    }
+                }
+            }
+        } catch (e) {}
+    }, 500);
+
+    window.chimLayout = chimLayout;
+
+})();

--- a/PrismaUI/views/CHIM/overlay.css
+++ b/PrismaUI/views/CHIM/overlay.css
@@ -15,7 +15,7 @@ body {
 /* Main Overlay Container */
 #chim-overlay {
     position: fixed;
-    top: 80px;
+    top: 20px;
     right: 20px;
     width: 320px;
     background: rgba(10, 10, 15, 0.92);
@@ -27,6 +27,12 @@ body {
     overflow: hidden;
     backdrop-filter: blur(8px);
 }
+
+/* Corner placement - driven by layout.js */
+#chim-overlay.chim-corner-top-left     { top: 20px !important;  left: 20px !important;  bottom: auto !important; right: auto !important; }
+#chim-overlay.chim-corner-top-right    { top: 20px !important;  right: 20px !important; bottom: auto !important; left: auto !important;  }
+#chim-overlay.chim-corner-bottom-left  { bottom: 20px !important; left: 20px !important;  top: auto !important;  right: auto !important; }
+#chim-overlay.chim-corner-bottom-right { bottom: 20px !important; right: 20px !important; top: auto !important;  left: auto !important;  }
 
 /* Header */
 .overlay-header {

--- a/PrismaUI/views/CHIM/overlay.html
+++ b/PrismaUI/views/CHIM/overlay.html
@@ -67,6 +67,7 @@
             </div>
         </div>
     </div>
+    <script src="layout.js"></script>
     <script src="overlay.js"></script>
 </body>
 </html>

--- a/PrismaUI/views/CHIM/overlay.js
+++ b/PrismaUI/views/CHIM/overlay.js
@@ -239,6 +239,12 @@
         }
     }
 
+    // Apply corner placement via shared layout manager
+    var overlayRoot = document.getElementById('chim-overlay');
+    if (window.chimLayout) {
+        window.chimLayout.apply(overlayRoot, 'overlay');
+    }
+
     // Initialize with loading state
     console.log('CHIM Overlay initialized');
     

--- a/PrismaUI/views/CHIM/settings_menu.css
+++ b/PrismaUI/views/CHIM/settings_menu.css
@@ -218,3 +218,70 @@ body {
     color: #999;
     font-size: 1.1em;
 }
+
+/* ── HUD Layout section ─────────────────────────────────────────────────── */
+
+/* Outer container: one row per view */
+.layout-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* Each row: label on the left, 2×2 picker on the right */
+.layout-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.layout-label {
+    flex: 0 0 130px;
+    font-size: 0.9em;
+    color: #ccc;
+    cursor: default;
+    user-select: none;
+}
+
+/* 2×2 grid of arrow buttons */
+.corner-picker {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    gap: 4px;
+}
+
+.corner-btn {
+    width: 38px;
+    height: 32px;
+    background: rgba(40, 40, 44, 0.8);
+    border: 1px solid rgba(242, 124, 17, 0.2);
+    border-radius: 5px;
+    color: #e8e8e8;
+    font-size: 1.1em;
+    cursor: pointer;
+    transition: all 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: auto;
+}
+
+.corner-btn:hover {
+    background: rgba(242, 124, 17, 0.25);
+    border-color: rgba(242, 124, 17, 0.6);
+    color: rgb(242, 124, 17);
+    box-shadow: 0 2px 8px rgba(242, 124, 17, 0.25);
+    transform: scale(1.1);
+}
+
+.corner-btn:active {
+    transform: scale(0.94);
+}
+
+.corner-btn.active {
+    background: rgba(242, 124, 17, 0.3);
+    border-color: rgb(242, 124, 17);
+    color: rgb(242, 124, 17);
+    box-shadow: 0 0 8px rgba(242, 124, 17, 0.4);
+}

--- a/PrismaUI/views/CHIM/settings_menu.html
+++ b/PrismaUI/views/CHIM/settings_menu.html
@@ -27,6 +27,109 @@
                 </div>
             </div>
 
+            <!-- HUD Layout / Corner Placement -->
+            <div class="settings-group">
+                <h2 class="group-title">HUD Layout</h2>
+                <div class="layout-grid">
+
+                    <!-- Chatbox -->
+                    <div class="layout-row">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('Chatbox: the main chat panel')"
+                              onmouseleave="clearDescription()">Chatbox</span>
+                        <div class="corner-picker" data-view="chatbox">
+                            <button type="button" class="corner-btn" data-corner="top-left"     onclick="setViewCorner('chatbox','top-left')">↖</button>
+                            <button type="button" class="corner-btn" data-corner="top-right"    onclick="setViewCorner('chatbox','top-right')">↗</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-left"  onclick="setViewCorner('chatbox','bottom-left')">↙</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-right" onclick="setViewCorner('chatbox','bottom-right')">↘</button>
+                        </div>
+                    </div>
+
+                    <!-- Overlay -->
+                    <div class="layout-row">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('Overlay: the CHIM status panel showing mode, model and agents')"
+                              onmouseleave="clearDescription()">Overlay</span>
+                        <div class="corner-picker" data-view="overlay">
+                            <button type="button" class="corner-btn" data-corner="top-left"     onclick="setViewCorner('overlay','top-left')">↖</button>
+                            <button type="button" class="corner-btn" data-corner="top-right"    onclick="setViewCorner('overlay','top-right')">↗</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-left"  onclick="setViewCorner('overlay','bottom-left')">↙</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-right" onclick="setViewCorner('overlay','bottom-right')">↘</button>
+                        </div>
+                    </div>
+
+                    <!-- Status HUD -->
+                    <div class="layout-row">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('Status HUD: the minimal pipeline indicator')"
+                              onmouseleave="clearDescription()">Status HUD</span>
+                        <div class="corner-picker" data-view="status_hud">
+                            <button type="button" class="corner-btn" data-corner="top-left"     onclick="setViewCorner('status_hud','top-left')">↖</button>
+                            <button type="button" class="corner-btn" data-corner="top-right"    onclick="setViewCorner('status_hud','top-right')">↗</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-left"  onclick="setViewCorner('status_hud','bottom-left')">↙</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-right" onclick="setViewCorner('status_hud','bottom-right')">↘</button>
+                        </div>
+                    </div>
+
+                    <!-- AI View: Left Panel -->
+                    <div class="layout-row">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('AI View – Identity &amp; Profile panel')"
+                              onmouseleave="clearDescription()">AI View · Identity</span>
+                        <div class="corner-picker" data-view="aiview_identity">
+                            <button type="button" class="corner-btn" data-corner="top-left"     onclick="setViewCorner('aiview_identity','top-left')">↖</button>
+                            <button type="button" class="corner-btn" data-corner="top-right"    onclick="setViewCorner('aiview_identity','top-right')">↗</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-left"  onclick="setViewCorner('aiview_identity','bottom-left')">↙</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-right" onclick="setViewCorner('aiview_identity','bottom-right')">↘</button>
+                        </div>
+                    </div>
+
+                    <!-- AI View: Right Panel -->
+                    <div class="layout-row">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('AI View – Settings panel')"
+                              onmouseleave="clearDescription()">AI View · Settings</span>
+                        <div class="corner-picker" data-view="aiview_settings">
+                            <button type="button" class="corner-btn" data-corner="top-left"     onclick="setViewCorner('aiview_settings','top-left')">↖</button>
+                            <button type="button" class="corner-btn" data-corner="top-right"    onclick="setViewCorner('aiview_settings','top-right')">↗</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-left"  onclick="setViewCorner('aiview_settings','bottom-left')">↙</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-right" onclick="setViewCorner('aiview_settings','bottom-right')">↘</button>
+                        </div>
+                    </div>
+
+                    <!-- AI View: Bio Panel -->
+                    <div class="layout-row">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('AI View – Bio panel: NPC biography &amp; relationships')"
+                              onmouseleave="clearDescription()">AI View · Bio</span>
+                        <div class="corner-picker" data-view="aiview_bio">
+                            <button type="button" class="corner-btn" data-corner="top-left"     onclick="setViewCorner('aiview_bio','top-left')">↖</button>
+                            <button type="button" class="corner-btn" data-corner="top-right"    onclick="setViewCorner('aiview_bio','top-right')">↗</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-left"  onclick="setViewCorner('aiview_bio','bottom-left')">↙</button>
+                            <button type="button" class="corner-btn" data-corner="bottom-right" onclick="setViewCorner('aiview_bio','bottom-right')">↘</button>
+                        </div>
+                    </div>
+
+                    <!-- Screen Edge Gap -->
+                    <div class="layout-row" style="margin-top: 8px;">
+                        <span class="layout-label"
+                              onmouseenter="showDescription('Distance from the edge of the screen for all HUD panels')"
+                              onmouseleave="clearDescription()">Screen Edge Gap</span>
+                        <div style="display: flex; align-items: center; gap: 10px; flex: 1;">
+                            <input type="range" id="layout-gap-slider" min="0" max="100" step="5" value="20" 
+                                   oninput="updateLayoutGap(this.value)" 
+                                   style="flex: 1; accent-color: rgb(242, 124, 17);">
+                            <span id="layout-gap-value" style="min-width: 40px; text-align: right; color: rgb(242, 124, 17); font-weight: bold;">20px</span>
+                        </div>
+                    </div>
+
+                </div>
+                
+                <div class="layout-actions" style="margin-top: 16px; display: flex; gap: 10px; justify-content: flex-end;">
+                    <button type="button" class="setting-btn" onclick="resetLayoutDefaults()" onmouseenter="showDescription('Reset all HUD panels to their default corners')" onmouseleave="clearDescription()" style="padding: 8px 16px; font-size: 0.9em; background: rgba(231, 76, 60, 0.2); border-color: rgba(231, 76, 60, 0.4);">Reset Defaults</button>
+                </div>
+            </div>
+
             <!-- Mode Options -->
             <div class="settings-group">
                 <h2 class="group-title">Mode</h2>
@@ -173,6 +276,7 @@
         </div>
     </div>
     
+    <script src="layout.js"></script>
     <script src="settings_menu.js"></script>
 </body>
 </html>

--- a/PrismaUI/views/CHIM/settings_menu.js
+++ b/PrismaUI/views/CHIM/settings_menu.js
@@ -183,9 +183,108 @@ window.setNPCTarget = function(npcName) {
     }
 };
 
+// ─── HUD Layout / Corner Placement ──────────────────────────────────────────
+
+/**
+ * Set the corner for a specific view.
+ * Called from the HTML onclick handlers: setViewCorner('overlay', 'top-left')
+ *
+ * @param {string} viewId   e.g. 'chatbox', 'overlay', 'status_hud', 'aiview_left' …
+ * @param {string} corner   'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+ */
+window.setViewCorner = function(viewId, corner) {
+    // Apply and persist immediately
+    if (window.chimLayout) {
+        window.chimLayout.setCorner(viewId, corner);
+    }
+
+    // Highlight the active button in the picker for this view
+    var picker = document.querySelector('.corner-picker[data-view="' + viewId + '"]');
+    if (picker) {
+        var btns = picker.querySelectorAll('.corner-btn');
+        for (var i = 0; i < btns.length; i++) {
+            var btn = btns[i];
+            if (btn.getAttribute('data-corner') === corner) {
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        }
+    }
+};
+
+/** Reset all layout settings to their defaults */
+window.resetLayoutDefaults = function() {
+    if (!window.chimLayout) return;
+    
+    var defaults = window.chimLayout.views;
+    for (var viewId in defaults) {
+        if (defaults.hasOwnProperty(viewId)) {
+            window.setViewCorner(viewId, defaults[viewId]);
+        }
+    }
+    
+    // Reset gap
+    window.updateLayoutGap(20);
+    var slider = document.getElementById('layout-gap-slider');
+    if (slider) slider.value = 20;
+    
+    // Show feedback
+    showDescription('Layout reset to defaults!');
+    setTimeout(clearDescription, 2000);
+};
+
+/** Update the gap from screen edges */
+window.updateLayoutGap = function(value) {
+    var gap = parseInt(value, 10);
+    var valueDisplay = document.getElementById('layout-gap-value');
+    if (valueDisplay) {
+        valueDisplay.textContent = gap + 'px';
+    }
+    
+    if (window.chimLayout) {
+        window.chimLayout.setGap(gap);
+    }
+};
+
+/** Restore all saved corner highlights when the settings menu opens */
+function initLayoutPickers() {
+    if (!window.chimLayout) return;
+    
+    // Restore gap
+    var gap = window.chimLayout.getGap();
+    var slider = document.getElementById('layout-gap-slider');
+    var valueDisplay = document.getElementById('layout-gap-value');
+    if (slider) slider.value = gap;
+    if (valueDisplay) valueDisplay.textContent = gap + 'px';
+    
+    var pickers = document.querySelectorAll('.corner-picker[data-view]');
+    for (var i = 0; i < pickers.length; i++) {
+        var picker = pickers[i];
+        var viewId = picker.getAttribute('data-view');
+        var saved  = window.chimLayout.getCorner(viewId);
+        
+        var btns = picker.querySelectorAll('.corner-btn');
+        for (var j = 0; j < btns.length; j++) {
+            var btn = btns[j];
+            if (btn.getAttribute('data-corner') === saved) {
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 // Initialize on load
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initSettingsMenu);
+    document.addEventListener('DOMContentLoaded', function() {
+        initSettingsMenu();
+        initLayoutPickers();
+    });
 } else {
     initSettingsMenu();
+    initLayoutPickers();
 }

--- a/PrismaUI/views/CHIM/status_hud.css
+++ b/PrismaUI/views/CHIM/status_hud.css
@@ -35,6 +35,12 @@ body {
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
 }
 
+/* Corner placement - driven by layout.js */
+#chim-status-hud.chim-corner-top-left     { top: 10px !important;    left: 10px !important;  bottom: auto !important; right: auto !important; }
+#chim-status-hud.chim-corner-top-right    { top: 10px !important;    right: 10px !important; bottom: auto !important; left: auto !important;  }
+#chim-status-hud.chim-corner-bottom-left  { bottom: 10px !important; left: 10px !important;  top: auto !important;    right: auto !important; }
+#chim-status-hud.chim-corner-bottom-right { bottom: 10px !important; right: 10px !important; top: auto !important;    left: auto !important;  }
+
 @keyframes fadeIn {
     from { opacity: 0; transform: translateY(-10px); }
     to { opacity: 1; transform: translateY(0); }

--- a/PrismaUI/views/CHIM/status_hud.html
+++ b/PrismaUI/views/CHIM/status_hud.html
@@ -30,6 +30,7 @@
             <span class="target-name" id="target-name">—</span>
         </div>
     </div>
+    <script src="layout.js"></script>
     <script src="status_hud.js"></script>
 </body>
 </html>

--- a/PrismaUI/views/CHIM/status_hud.js
+++ b/PrismaUI/views/CHIM/status_hud.js
@@ -159,6 +159,12 @@
         startPolling();
     }
     
+    // Apply corner placement via shared layout manager
+    var hudRoot = document.getElementById('chim-status-hud');
+    if (window.chimLayout) {
+        window.chimLayout.apply(hudRoot, 'status_hud');
+    }
+
     // Cleanup
     window.addEventListener('beforeunload', stopPolling);
     


### PR DESCRIPTION
## What

<!-- Briefly describe what changes this PR introduces. Use bullet points for multiple changes. -->

* feat: add view positioning settings to PrismaUI settings menu
  * corner placement settings for non-centered views, i.e. Chatbox, Overlay, Status HUD, AI View.
  * screen edge gap (slider; in pixels)
  * reset defaults button

## Screenshot

<!-- If applicable, add screenshots to help explain your changes -->
<!-- Delete this section if not applicable -->

<img width="1268" height="1345" alt="image" src="https://github.com/user-attachments/assets/1d91d1dd-bf37-4d14-b073-08a4b74a8758" />


## Why

<!-- Explain the motivation behind these changes. What problem does this solve? -->

The CSS-hardcoded PrismaUI corner placements can be intrusive depending on the user's Skyrim setup. For example, SkyUI—which is extremely popular—has active effects in the top right. This would get in the way of the _Status HUD_ view. So adding an option to place it in another corner is helpful.

## Related PRs

<!-- Does this PR relate to or rely on another PR in another CHIM repo? -->
<!-- If yes, link the related PR(s) below: -->

N/A


## Notes

<!-- Any additional context, implementation details, breaking changes, or dependencies -->
<!-- Delete this section if not applicable -->

* ~I am not sure if these settings will persist properly. It uses `localStorage` rather than saving via SKSE.~ Settings seem to persist. Possibly this has something to do with PrismaUI's underlying use of the Ultralight toolkit.